### PR TITLE
feat: ip addr in config.toml

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -1,5 +1,6 @@
 [setup]
-# The websocket will run on `127.0.0.1:{port}`
+# The websocket will run on `{ip_addr}:{port}`
+ip_addr = "127.0.0.1"
 port = 7727
 # How detailed you want the logs to be.
 # Allowed values: "off", "error", "warn", "info", "debug", "trace"

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,8 @@
-use std::{fs::File, io::Read};
+use std::{
+    fs::File,
+    io::Read,
+    net::{IpAddr, Ipv4Addr},
+};
 
 use eyre::Context;
 use serde::Deserialize;
@@ -51,6 +55,8 @@ impl Config {
 pub struct Setup {
     #[serde(default = "Setup::default_log")]
     pub log: Box<str>,
+    #[serde(default = "Setup::default_ip_addr")]
+    pub ip_addr: IpAddr,
     #[serde(default = "Setup::default_port")]
     pub port: u16,
     #[serde(default = "Setup::default_interval")]
@@ -71,6 +77,10 @@ pub struct OsuConfig {
 impl Setup {
     fn default_log() -> Box<str> {
         Box::from("info")
+    }
+
+    const fn default_ip_addr() -> IpAddr {
+        IpAddr::V4(Ipv4Addr::LOCALHOST)
     }
 
     const fn default_port() -> u16 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,10 +40,7 @@ extern crate eyre;
 #[macro_use]
 extern crate tracing;
 
-use std::{
-    net::{Ipv4Addr, SocketAddrV4},
-    sync::Arc,
-};
+use std::{net::SocketAddr, sync::Arc};
 
 use eyre::{Context as _, Result};
 use osu::Osu;
@@ -67,7 +64,7 @@ async fn main() -> Result<()> {
     let osu = Osu::new(osu).context("Failed to create osu! client")?;
     let ctx = Arc::new(Context::new(&setup));
 
-    let addr = SocketAddrV4::new(Ipv4Addr::LOCALHOST, setup.port);
+    let addr = SocketAddr::new(setup.ip_addr, setup.port);
     let listener = TcpListener::bind(addr).await.unwrap();
     info!("Listening on {addr}...");
 


### PR DESCRIPTION
Makes the IP address confugrable via `config.toml` instead of always being set to `127.0.0.1`. Convenient e.g. for docker containers.